### PR TITLE
feat: mcp_server/ 패키지 구현 - Google Calendar MCP 서버 #9

### DIFF
--- a/mcp_server/auth.py
+++ b/mcp_server/auth.py
@@ -1,0 +1,45 @@
+"""Google OAuth 2.0 인증 - 토큰 저장/갱신."""
+
+import json
+from pathlib import Path
+
+from google.auth.transport.requests import Request
+from google.oauth2.credentials import Credentials
+from google_auth_oauthlib.flow import InstalledAppFlow
+
+SCOPES = ["https://www.googleapis.com/auth/calendar"]
+
+
+def get_google_credentials(
+    credentials_path: Path,
+    token_path: Path,
+) -> Credentials:
+    """Google OAuth 2.0 자격증명을 가져온다.
+
+    토큰 파일이 있으면 로드하고, 만료되었으면 갱신한다.
+    없으면 OAuth 플로우를 실행하여 새 토큰을 획득한다.
+    """
+    creds = None
+
+    if token_path.exists():
+        creds = Credentials.from_authorized_user_file(str(token_path), SCOPES)
+
+    if not creds or not creds.valid:
+        if creds and creds.expired and creds.refresh_token:
+            creds.refresh(Request())
+        else:
+            if not credentials_path.exists():
+                raise FileNotFoundError(
+                    f"Google credentials 파일을 찾을 수 없습니다: {credentials_path}\n"
+                    "Google Cloud Console에서 OAuth 2.0 클라이언트 ID를 생성하고 "
+                    "credentials.json을 프로젝트 루트에 배치하세요."
+                )
+            flow = InstalledAppFlow.from_client_secrets_file(
+                str(credentials_path), SCOPES
+            )
+            creds = flow.run_local_server(port=0)
+
+        # 토큰 저장
+        token_path.write_text(creds.to_json())
+
+    return creds

--- a/mcp_server/calendar_tools.py
+++ b/mcp_server/calendar_tools.py
@@ -1,0 +1,186 @@
+"""Google Calendar MCP 도구들."""
+
+from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo
+
+from googleapiclient.discovery import build
+
+from config.settings import settings
+from mcp_server.auth import get_google_credentials
+
+
+def _get_calendar_service():
+    """Google Calendar API 서비스 객체를 반환한다."""
+    creds = get_google_credentials(
+        settings.google_credentials_path,
+        settings.google_token_path,
+    )
+    return build("calendar", "v3", credentials=creds)
+
+
+def list_events(
+    time_min: str | None = None,
+    time_max: str | None = None,
+    max_results: int = 10,
+) -> list[dict]:
+    """일정 목록을 조회한다.
+
+    Args:
+        time_min: 조회 시작 시간 (ISO 8601). 기본값: 현재 시간
+        time_max: 조회 종료 시간 (ISO 8601). 기본값: 오늘 끝
+        max_results: 최대 결과 수
+    """
+    service = _get_calendar_service()
+    tz = ZoneInfo(settings.timezone)
+    now = datetime.now(tz)
+
+    if not time_min:
+        time_min = now.isoformat()
+    if not time_max:
+        end_of_day = now.replace(hour=23, minute=59, second=59)
+        time_max = end_of_day.isoformat()
+
+    result = (
+        service.events()
+        .list(
+            calendarId=settings.google_calendar_id,
+            timeMin=time_min,
+            timeMax=time_max,
+            maxResults=max_results,
+            singleEvents=True,
+            orderBy="startTime",
+        )
+        .execute()
+    )
+
+    events = []
+    for event in result.get("items", []):
+        start = event["start"].get("dateTime", event["start"].get("date"))
+        end = event["end"].get("dateTime", event["end"].get("date"))
+        events.append({
+            "event_id": event["id"],
+            "summary": event.get("summary", "(제목 없음)"),
+            "start_time": start,
+            "end_time": end,
+            "description": event.get("description", ""),
+            "location": event.get("location", ""),
+            "html_link": event.get("htmlLink", ""),
+        })
+    return events
+
+
+def create_event(
+    summary: str,
+    start_time: str,
+    end_time: str,
+    description: str = "",
+    location: str = "",
+) -> dict:
+    """새 일정을 생성한다.
+
+    Args:
+        summary: 일정 제목
+        start_time: 시작 시간 (ISO 8601)
+        end_time: 종료 시간 (ISO 8601)
+        description: 일정 설명
+        location: 장소
+    """
+    service = _get_calendar_service()
+
+    event_body = {
+        "summary": summary,
+        "description": description,
+        "location": location,
+        "start": {"dateTime": start_time, "timeZone": settings.timezone},
+        "end": {"dateTime": end_time, "timeZone": settings.timezone},
+    }
+
+    event = (
+        service.events()
+        .insert(calendarId=settings.google_calendar_id, body=event_body)
+        .execute()
+    )
+
+    return {
+        "event_id": event["id"],
+        "summary": event.get("summary", ""),
+        "start_time": event["start"].get("dateTime", ""),
+        "end_time": event["end"].get("dateTime", ""),
+        "description": event.get("description", ""),
+        "location": event.get("location", ""),
+        "html_link": event.get("htmlLink", ""),
+    }
+
+
+def update_event(
+    event_id: str,
+    summary: str | None = None,
+    start_time: str | None = None,
+    end_time: str | None = None,
+    description: str | None = None,
+    location: str | None = None,
+) -> dict:
+    """기존 일정을 수정한다.
+
+    Args:
+        event_id: 수정할 이벤트 ID
+        summary: 변경할 제목
+        start_time: 변경할 시작 시간
+        end_time: 변경할 종료 시간
+        description: 변경할 설명
+        location: 변경할 장소
+    """
+    service = _get_calendar_service()
+
+    event = (
+        service.events()
+        .get(calendarId=settings.google_calendar_id, eventId=event_id)
+        .execute()
+    )
+
+    if summary is not None:
+        event["summary"] = summary
+    if start_time is not None:
+        event["start"] = {"dateTime": start_time, "timeZone": settings.timezone}
+    if end_time is not None:
+        event["end"] = {"dateTime": end_time, "timeZone": settings.timezone}
+    if description is not None:
+        event["description"] = description
+    if location is not None:
+        event["location"] = location
+
+    updated = (
+        service.events()
+        .update(
+            calendarId=settings.google_calendar_id,
+            eventId=event_id,
+            body=event,
+        )
+        .execute()
+    )
+
+    return {
+        "event_id": updated["id"],
+        "summary": updated.get("summary", ""),
+        "start_time": updated["start"].get("dateTime", ""),
+        "end_time": updated["end"].get("dateTime", ""),
+        "description": updated.get("description", ""),
+        "location": updated.get("location", ""),
+        "html_link": updated.get("htmlLink", ""),
+    }
+
+
+def delete_event(event_id: str) -> dict:
+    """일정을 삭제한다.
+
+    Args:
+        event_id: 삭제할 이벤트 ID
+    """
+    service = _get_calendar_service()
+
+    service.events().delete(
+        calendarId=settings.google_calendar_id,
+        eventId=event_id,
+    ).execute()
+
+    return {"event_id": event_id, "deleted": True}

--- a/mcp_server/models.py
+++ b/mcp_server/models.py
@@ -1,0 +1,44 @@
+"""Pydantic 모델 - MCP 도구 입출력 스키마."""
+
+from pydantic import BaseModel, Field
+
+
+class EventListQuery(BaseModel):
+    """일정 조회 요청."""
+
+    time_min: str | None = Field(default=None, description="조회 시작 시간 (ISO 8601). 기본값: 현재 시간")
+    time_max: str | None = Field(default=None, description="조회 종료 시간 (ISO 8601). 기본값: 오늘 끝")
+    max_results: int = Field(default=10, description="최대 결과 수")
+
+
+class EventCreate(BaseModel):
+    """일정 생성 요청."""
+
+    summary: str = Field(description="일정 제목")
+    start_time: str = Field(description="시작 시간 (ISO 8601, e.g. 2025-01-15T14:00:00+09:00)")
+    end_time: str = Field(description="종료 시간 (ISO 8601)")
+    description: str = Field(default="", description="일정 설명")
+    location: str = Field(default="", description="장소")
+
+
+class EventUpdate(BaseModel):
+    """일정 수정 요청."""
+
+    event_id: str = Field(description="Google Calendar 이벤트 ID")
+    summary: str | None = Field(default=None, description="변경할 제목")
+    start_time: str | None = Field(default=None, description="변경할 시작 시간")
+    end_time: str | None = Field(default=None, description="변경할 종료 시간")
+    description: str | None = Field(default=None, description="변경할 설명")
+    location: str | None = Field(default=None, description="변경할 장소")
+
+
+class EventResponse(BaseModel):
+    """일정 응답."""
+
+    event_id: str
+    summary: str
+    start_time: str
+    end_time: str
+    description: str = ""
+    location: str = ""
+    html_link: str = ""

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -1,0 +1,54 @@
+"""FastMCP 서버 - Google Calendar 도구를 MCP 프로토콜로 노출."""
+
+import sys
+from pathlib import Path
+
+# 프로젝트 루트를 sys.path에 추가 (standalone 실행 시)
+_project_root = str(Path(__file__).resolve().parent.parent)
+if _project_root not in sys.path:
+    sys.path.insert(0, _project_root)
+
+from mcp.server.fastmcp import FastMCP
+
+from mcp_server.calendar_tools import (
+    create_event,
+    delete_event,
+    list_events,
+    update_event,
+)
+from mcp_server.models import (
+    EventCreate,
+    EventListQuery,
+    EventResponse,
+    EventUpdate,
+)
+
+mcp = FastMCP("Google Calendar Assistant")
+
+
+@mcp.tool()
+def calendar_list_events(req: EventListQuery) -> list[EventResponse]:
+    """Google Calendar 일정을 조회합니다."""
+    return list_events(req.time_min, req.time_max, req.max_results)
+
+
+@mcp.tool()
+def calendar_create_event(req: EventCreate) -> EventResponse:
+    """Google Calendar에 새 일정을 생성합니다."""
+    return create_event(req.summary, req.start_time, req.end_time, req.description, req.location)
+
+
+@mcp.tool()
+def calendar_update_event(req: EventUpdate) -> EventResponse:
+    """기존 Google Calendar 일정을 수정합니다."""
+    return update_event(req.event_id, req.summary, req.start_time, req.end_time, req.description, req.location)
+
+
+@mcp.tool()
+def calendar_delete_event(event_id: str) -> dict:
+    """Google Calendar 일정을 삭제합니다."""
+    return delete_event(event_id)
+
+
+if __name__ == "__main__":
+    mcp.run()


### PR DESCRIPTION
## 관련 이슈
closes #9

## 작업 내용
`mcp_server/` 패키지 구현 - Google Calendar 기능을 MCP 프로토콜로 노출

## 커밋 목록
- `feat: mcp_server 패키지화` - `__init__.py` 추가로 폴더 패키지화
- `feat: 권한 관리 툴 작성` - google-auth로 token.json 검사, google-auth-oauthlib로 OAuth 플로우 구현
- `feat: mcp툴 작성` - auth 인증서 기반 Google Calendar 조회/생성/수정/삭제 기능 구현
- `feat: calendar_tool의 타입 검사 클래스 생성` - Pydantic 모델로 입출력 타입 검증 (EventListQuery, EventCreate, EventUpdate, EventResponse)
- `feat: mcp래퍼로 툴 감싸서 mcp툴로 만들기` - FastMCP `@mcp.tool()` 데코레이터로 4개 도구 등록, standalone 실행 지원

## 구조
```
mcp_server/
├── __init__.py         # 패키지화
├── auth.py             # Google OAuth 2.0 인증
├── calendar_tools.py   # Google Calendar API 호출
├── models.py           # Pydantic 입출력 모델
└── server.py           # FastMCP 서버 (MCP 도구 등록)
```