### PR TITLE
feat: agents/ 패키지 구현 - BaseAgent 추상 클래스 및 에이전트 구현 #11

### DIFF
--- a/agents/base.py
+++ b/agents/base.py
@@ -1,0 +1,28 @@
+"""BaseAgent 추상 클래스."""
+
+from abc import ABC, abstractmethod
+
+
+class BaseAgent(ABC):
+    """모든 에이전트의 기본 클래스."""
+
+    def __init__(self, name: str):
+        self.name = name
+        self.conversation_history: list[dict] = []
+
+    def add_message(self, role: str, content: str):
+        """대화 히스토리에 메시지를 추가한다."""
+        self.conversation_history.append({"role": role, "content": content})
+
+    def clear_history(self):
+        """대화 히스토리를 초기화한다."""
+        self.conversation_history.clear()
+
+    @abstractmethod
+    async def process(self, user_input: str) -> dict:
+        """사용자 입력을 처리하고 결과를 반환한다.
+
+        Returns:
+            처리 결과 딕셔너리
+        """
+        ...

--- a/agents/calendar_agent.py
+++ b/agents/calendar_agent.py
@@ -1,0 +1,111 @@
+"""Calendar Agent - MCP 클라이언트로 Google Calendar 도구 호출."""
+
+import asyncio
+import json
+import sys
+from pathlib import Path
+
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+
+from agents.base import BaseAgent
+
+
+class CalendarAgent(BaseAgent):
+    """MCP 서버를 통해 Google Calendar를 조작하는 에이전트."""
+
+    def __init__(self):
+        super().__init__("CalendarAgent")
+        self._server_script = str(
+            Path(__file__).resolve().parent.parent / "mcp_server" / "server.py"
+        )
+
+    async def process(self, user_input: str) -> dict:
+        """직접 호출되지 않음. call_tool을 사용."""
+        return {"error": "Use call_tool() instead"}
+
+    async def call_tool(self, tool_name: str, arguments: dict) -> dict:
+        """MCP 서버의 도구를 호출한다.
+
+        Args:
+            tool_name: 호출할 도구 이름 (calendar_list_events 등)
+            arguments: 도구에 전달할 인자
+        """
+        server_params = StdioServerParameters(
+            command=sys.executable,
+            args=[self._server_script],
+        )
+
+        async with stdio_client(server_params) as (read, write):
+            async with ClientSession(read, write) as session:
+                await session.initialize()
+
+                result = await session.call_tool(tool_name, arguments)
+
+                # MCP 응답에서 텍스트 콘텐츠 추출
+                if result.content:
+                    for item in result.content:
+                        if hasattr(item, "text"):
+                            return json.loads(item.text)
+                return {"error": "No response from MCP server"}
+
+    async def list_events(
+        self,
+        time_min: str | None = None,
+        time_max: str | None = None,
+        max_results: int = 10,
+    ) -> list[dict] | dict:
+        """일정 목록을 조회한다."""
+        args = {"max_results": max_results}
+        if time_min:
+            args["time_min"] = time_min
+        if time_max:
+            args["time_max"] = time_max
+        return await self.call_tool("calendar_list_events", args)
+
+    async def create_event(
+        self,
+        summary: str,
+        start_time: str,
+        end_time: str,
+        description: str = "",
+        location: str = "",
+    ) -> dict:
+        """새 일정을 생성한다."""
+        return await self.call_tool(
+            "calendar_create_event",
+            {
+                "summary": summary,
+                "start_time": start_time,
+                "end_time": end_time,
+                "description": description,
+                "location": location,
+            },
+        )
+
+    async def update_event(
+        self,
+        event_id: str,
+        summary: str | None = None,
+        start_time: str | None = None,
+        end_time: str | None = None,
+        description: str | None = None,
+        location: str | None = None,
+    ) -> dict:
+        """기존 일정을 수정한다."""
+        args = {"event_id": event_id}
+        if summary is not None:
+            args["summary"] = summary
+        if start_time is not None:
+            args["start_time"] = start_time
+        if end_time is not None:
+            args["end_time"] = end_time
+        if description is not None:
+            args["description"] = description
+        if location is not None:
+            args["location"] = location
+        return await self.call_tool("calendar_update_event", args)
+
+    async def delete_event(self, event_id: str) -> dict:
+        """일정을 삭제한다."""
+        return await self.call_tool("calendar_delete_event", {"event_id": event_id})

--- a/agents/conversation_agent.py
+++ b/agents/conversation_agent.py
@@ -1,0 +1,42 @@
+"""Conversation Agent - 한국어 의도/엔티티 추출."""
+
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+from agents.base import BaseAgent
+from config.settings import settings
+from llm.provider import chat_completion_json
+from llm.prompts import INTENT_EXTRACTION_PROMPT
+from agents.models import IntentResult
+
+
+class ConversationAgent(BaseAgent):
+    """사용자 입력에서 일정 관련 의도와 엔티티를 추출하는 에이전트."""
+
+    def __init__(self):
+        super().__init__("ConversationAgent")
+
+    async def process(self, user_input: str) -> dict:
+        """사용자 입력을 분석하여 구조화된 의도를 반환한다."""
+        tz = ZoneInfo(settings.timezone)
+        now = datetime.now(tz)
+
+        system_prompt = INTENT_EXTRACTION_PROMPT.format(
+            current_time=now.isoformat(),
+            timezone=settings.timezone,
+        )
+
+        messages = [
+            {"role": "system", "content": system_prompt},
+            *self.conversation_history,
+            {"role": "user", "content": user_input},
+        ]
+
+        result = await chat_completion_json(messages=messages)
+
+        # raw_text 보정
+        result["raw_text"] = user_input
+
+        # Pydantic 검증
+        intent = IntentResult(**result)
+        return intent.model_dump()

--- a/agents/models.py
+++ b/agents/models.py
@@ -1,0 +1,19 @@
+"""Pydantic 모델 - Agent 입출력 스키마."""
+
+from pydantic import BaseModel, Field
+
+
+class IntentResult(BaseModel):
+    """대화에서 추출된 의도."""
+
+    intent: str = Field(description="create | list | update | delete | chat")
+    summary: str | None = Field(default=None, description="일정 제목")
+    start_time: str | None = Field(default=None, description="시작 시간 ISO 8601")
+    end_time: str | None = Field(default=None, description="종료 시간 ISO 8601")
+    description: str | None = Field(default=None, description="일정 설명")
+    location: str | None = Field(default=None, description="장소")
+    event_id: str | None = Field(default=None, description="수정/삭제 대상 이벤트 ID")
+    date_range_start: str | None = Field(default=None, description="조회 시작일")
+    date_range_end: str | None = Field(default=None, description="조회 종료일")
+    raw_text: str = Field(default="", description="원본 사용자 입력")
+    confidence: float = Field(default=0.0, description="추출 신뢰도 0~1")


### PR DESCRIPTION
## 관련 이슈
closes #11

## 작업 내용
`agents/` 패키지 구현 - 에이전트 추상화 계층 및 핵심 에이전트 구현

## 커밋 목록
- `feat: agents 패키지화` - `__init__.py` 추가로 폴더 패키지화
- `feat: BaseAgent 추상 클래스 구현` - ABC 기반 추상 클래스, 대화 히스토리 관리
- `feat: CalendarAgent 구현` - MCP 클라이언트로 Google Calendar 도구 호출 (3계층 구조)
- `feat: ConversationAgent 구현` - LLM 기반 사용자 의도/엔티티 추출
- `feat: IntentResult 모델 구현` - Pydantic 기반 LLM 응답 타입 검증

## 구조
```
agents/
├── __init__.py           # 패키지화
├── base.py               # BaseAgent 추상 클래스 (ABC)
├── calendar_agent.py     # MCP 클라이언트 에이전트 (Google Calendar)
├── conversation_agent.py # LLM 의도 추출 에이전트
└── models.py             # IntentResult Pydantic 모델
```

## 참고
- `orchestrator.py`는 skills/ 패키지 이해 후 별도 PR로 추가 예정